### PR TITLE
#4: Split Connection and ConnectionEntity

### DIFF
--- a/src/main/java/cz/blahami2/dbviewer/connections/ConnectionsApi.java
+++ b/src/main/java/cz/blahami2/dbviewer/connections/ConnectionsApi.java
@@ -1,10 +1,6 @@
 package cz.blahami2.dbviewer.connections;
 
-import cz.blahami2.dbviewer.model.Column;
-import cz.blahami2.dbviewer.model.Preview;
-import cz.blahami2.dbviewer.model.Schema;
-import cz.blahami2.dbviewer.data.entity.Connection;
-import cz.blahami2.dbviewer.model.Table;
+import cz.blahami2.dbviewer.model.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -12,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.List;
@@ -46,7 +43,7 @@ public class ConnectionsApi {
     }
 
     @PostMapping
-    public ResponseEntity<Connection> addConnection(@RequestBody Connection connection) {
+    public ResponseEntity<Connection> addConnection(@RequestBody @Valid Connection connection) {
         log.debug("adding connection: {}", connection);
         Connection savedConnection = connectionsService.add(connection);
         URI location = getNewResourceLocation(savedConnection.getId());
@@ -54,7 +51,7 @@ public class ConnectionsApi {
     }
 
     @PutMapping(path = "/{id}")
-    public ResponseEntity<Connection> putConnection(@PathVariable("id") Long id, @RequestBody Connection connection) {
+    public ResponseEntity<Connection> putConnection(@PathVariable("id") Long id, @RequestBody @Valid Connection connection) {
         log.debug("updating connection: {}", connection);
         Connection updatedConnection = connectionsService.update(connection);
         return ResponseEntity.ok(updatedConnection);

--- a/src/main/java/cz/blahami2/dbviewer/connections/ConnectionsConfiguration.java
+++ b/src/main/java/cz/blahami2/dbviewer/connections/ConnectionsConfiguration.java
@@ -1,7 +1,8 @@
 package cz.blahami2.dbviewer.connections;
 
+import cz.blahami2.dbviewer.connections.mapping.ConnectionMapper;
 import cz.blahami2.dbviewer.data.DatabaseConnection;
-import cz.blahami2.dbviewer.data.entity.Connection;
+import cz.blahami2.dbviewer.model.Connection;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,5 +24,10 @@ public class ConnectionsConfiguration {
                 connection.getPassword(),
                 connection.getDatabaseName()
         );
+    }
+
+    @Bean
+    public ConnectionMapper getConnectionMapper(){
+        return new ConnectionMapper();
     }
 }

--- a/src/main/java/cz/blahami2/dbviewer/connections/ConnectionsService.java
+++ b/src/main/java/cz/blahami2/dbviewer/connections/ConnectionsService.java
@@ -1,52 +1,63 @@
 package cz.blahami2.dbviewer.connections;
 
-import cz.blahami2.dbviewer.data.entity.Connection;
+import cz.blahami2.dbviewer.connections.mapping.ConnectionMapper;
+import cz.blahami2.dbviewer.data.entity.ConnectionEntity;
 import cz.blahami2.dbviewer.data.repository.ConnectionsRepository;
+import cz.blahami2.dbviewer.model.Connection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class ConnectionsService {
 
     private final ConnectionsRepository repository;
+    private final ConnectionMapper connectionMapper;
 
     @Autowired
-    public ConnectionsService(ConnectionsRepository repository) {
+    public ConnectionsService(ConnectionsRepository repository, ConnectionMapper connectionMapper) {
         this.repository = repository;
+        this.connectionMapper = connectionMapper;
     }
 
+
     public List<Connection> getAll() {
-        return repository.findAll();
+        return repository.findAll().stream().map(connectionMapper::toConnection).collect(Collectors.toList());
     }
 
     public Connection add(Connection newConnection) {
-        return repository.save(newConnection);
+        ConnectionEntity connectionEntity = connectionMapper.toConnectionEntity(newConnection);
+        ConnectionEntity savedConnectionEntity = repository.save(connectionEntity);
+        return connectionMapper.toConnection(savedConnectionEntity);
     }
 
     public Connection get(long id) {
-        return findOrError(id);
+        ConnectionEntity connectionEntity = findOrError(id);
+        return connectionMapper.toConnection(connectionEntity);
     }
 
     public Connection update(Connection updatedConnection) {
-        Connection originalConnection = findOrError(updatedConnection.getId());
-        Optional.ofNullable(updatedConnection.getName()).ifPresent(originalConnection::setName);
-        Optional.ofNullable(updatedConnection.getHostName()).ifPresent(originalConnection::setHostName);
-        Optional.ofNullable(updatedConnection.getDatabaseName()).ifPresent(originalConnection::setDatabaseName);
-        Optional.ofNullable(updatedConnection.getUserName()).ifPresent(originalConnection::setUserName);
-        Optional.ofNullable(updatedConnection.getPassword()).ifPresent(originalConnection::setPassword);
-        return repository.save(originalConnection);
+        ConnectionEntity originalConnectionEntity = findOrError(updatedConnection.getId());
+        Optional.ofNullable(updatedConnection.getName()).ifPresent(originalConnectionEntity::setName);
+        Optional.ofNullable(updatedConnection.getHostName()).ifPresent(originalConnectionEntity::setHostName);
+        Optional.ofNullable(updatedConnection.getDatabaseName()).ifPresent(originalConnectionEntity::setDatabaseName);
+        Optional.ofNullable(updatedConnection.getUserName()).ifPresent(originalConnectionEntity::setUserName);
+        Optional.ofNullable(updatedConnection.getPassword()).ifPresent(originalConnectionEntity::setPassword);
+        ConnectionEntity savedOriginalConnectionEntity = repository.save(originalConnectionEntity);
+        return connectionMapper.toConnection(savedOriginalConnectionEntity);
     }
 
     public Connection delete(long id) {
-        Connection connection = findOrError(id);
+        ConnectionEntity connectionEntity = findOrError(id);
+        Connection connection = connectionMapper.toConnection(connectionEntity);
         repository.deleteById(id);
         return connection;
     }
 
-    private Connection findOrError(long id) {
+    private ConnectionEntity findOrError(long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new IllegalStateException(
                         "Non-existing connection should have been handled during validation phase"

--- a/src/main/java/cz/blahami2/dbviewer/connections/DatabaseDetailsService.java
+++ b/src/main/java/cz/blahami2/dbviewer/connections/DatabaseDetailsService.java
@@ -1,11 +1,7 @@
 package cz.blahami2.dbviewer.connections;
 
 import cz.blahami2.dbviewer.data.DatabaseConnection;
-import cz.blahami2.dbviewer.data.entity.Connection;
-import cz.blahami2.dbviewer.model.Column;
-import cz.blahami2.dbviewer.model.Preview;
-import cz.blahami2.dbviewer.model.Schema;
-import cz.blahami2.dbviewer.model.Table;
+import cz.blahami2.dbviewer.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 public class DatabaseDetailsService {

--- a/src/main/java/cz/blahami2/dbviewer/connections/mapping/ConnectionMapper.java
+++ b/src/main/java/cz/blahami2/dbviewer/connections/mapping/ConnectionMapper.java
@@ -1,0 +1,28 @@
+package cz.blahami2.dbviewer.connections.mapping;
+
+import cz.blahami2.dbviewer.data.entity.ConnectionEntity;
+import cz.blahami2.dbviewer.model.Connection;
+
+public class ConnectionMapper {
+
+    public Connection toConnection(ConnectionEntity connectionEntity) {
+        return new Connection(
+                connectionEntity.getId(),
+                connectionEntity.getName(),
+                connectionEntity.getHostName(),
+                connectionEntity.getDatabaseName(),
+                connectionEntity.getUserName(),
+                connectionEntity.getPassword()
+        );
+    }
+
+    public ConnectionEntity toConnectionEntity(Connection connection) {
+        return new ConnectionEntity(
+                connection.getName(),
+                connection.getHostName(),
+                connection.getDatabaseName(),
+                connection.getUserName(),
+                connection.getPassword()
+        );
+    }
+}

--- a/src/main/java/cz/blahami2/dbviewer/data/entity/ConnectionEntity.java
+++ b/src/main/java/cz/blahami2/dbviewer/data/entity/ConnectionEntity.java
@@ -1,0 +1,35 @@
+package cz.blahami2.dbviewer.data.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+// TODO split host and port
+// TODO map to internal immutable model if overused
+// TODO finish validations
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Entity
+public class ConnectionEntity extends BaseEntity {
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "host_name", nullable = false)
+    private String hostName;
+
+    @Column(name = "database_name", nullable = false)
+    private String databaseName;
+
+    @Column(name = "user_name", nullable = false)
+    private String userName;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+}

--- a/src/main/java/cz/blahami2/dbviewer/data/repository/ConnectionsRepository.java
+++ b/src/main/java/cz/blahami2/dbviewer/data/repository/ConnectionsRepository.java
@@ -1,8 +1,8 @@
 package cz.blahami2.dbviewer.data.repository;
 
-import cz.blahami2.dbviewer.data.entity.Connection;
+import cz.blahami2.dbviewer.data.entity.ConnectionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ConnectionsRepository extends JpaRepository<Connection, Long> {
+public interface ConnectionsRepository extends JpaRepository<ConnectionEntity, Long> {
 
 }

--- a/src/main/java/cz/blahami2/dbviewer/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/cz/blahami2/dbviewer/exceptions/GlobalExceptionHandler.java
@@ -3,25 +3,26 @@ package cz.blahami2.dbviewer.exceptions;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.validation.ConstraintViolationException;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 // TODO handle more exceptions
+// TODO custom error messages
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiError> handleConstraintViolationException(ConstraintViolationException ex) {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         return ResponseEntity.badRequest().body(new ApiError(
                 "Validation has failed",
-                ex.getConstraintViolations().stream()
-                        .map(violation -> violation.getPropertyPath() + " " + violation.getMessage())
-                        .collect(Collectors.toList())
+                Arrays.asList(ex.getMessage())
         ));
     }
 

--- a/src/main/java/cz/blahami2/dbviewer/model/Connection.java
+++ b/src/main/java/cz/blahami2/dbviewer/model/Connection.java
@@ -1,48 +1,37 @@
-package cz.blahami2.dbviewer.data.entity;
+package cz.blahami2.dbviewer.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
-// TODO split host and port
-// TODO map to internal immutable model if overused
-// TODO finish validations
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = true)
-@Data
-@Entity
-public class Connection extends BaseEntity {
+public class Connection {
 
-    @Column(name = "name", nullable = false)
+    private Long id;
+
     @NotEmpty
     @Size(min = 1, max = 256)
     private String name;
 
-    @Column(name = "host_name", nullable = false)
     @NotEmpty
     @Size(min = 1, max = 256)
     private String hostName;
 
-    @Column(name = "database_name", nullable = false)
     @NotEmpty
     @Size(min = 1, max = 128)
     @Pattern(regexp = "^[a-zA-Z0-9_-]*$", message = "must contain only alpha-numeric characters, under-scores or hyphens")
     private String databaseName;
 
-    @Column(name = "user_name", nullable = false)
     @NotEmpty
     @Size(min = 1, max = 128)
     private String userName;
 
-    @Column(name = "password", nullable = false)
     @NotEmpty
     @Size(min = 6, max = 128)
     private String password;

--- a/src/test/java/cz/blahami2/dbviewer/connections/ConnectionsApiIT.java
+++ b/src/test/java/cz/blahami2/dbviewer/connections/ConnectionsApiIT.java
@@ -3,7 +3,7 @@ package cz.blahami2.dbviewer.connections;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
-import cz.blahami2.dbviewer.data.entity.Connection;
+import cz.blahami2.dbviewer.data.entity.ConnectionEntity;
 import cz.blahami2.dbviewer.data.repository.ConnectionsRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,11 +33,11 @@ public class ConnectionsApiIT {
     private ConnectionsRepository repository;
 
     private ConnectionsApiWrapper api;
-    private static final List<Connection> CONNECTIONS = Arrays.asList(
-            new Connection("connection1", "localhost", "testdb", "postgres", "postgres"),
-            new Connection("connection2", "localhost", "testdb", "postgres", "postgres")
+    private static final List<ConnectionEntity> CONNECTIONS = Arrays.asList(
+            new ConnectionEntity("connection1", "localhost", "testdb", "postgres", "postgres"),
+            new ConnectionEntity("connection2", "localhost", "testdb", "postgres", "postgres")
     );
-    private List<Connection> savedConnections;
+    private List<ConnectionEntity> savedConnections;
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
@@ -69,7 +69,7 @@ public class ConnectionsApiIT {
     @Test
     void returnsConnectionOnGetById() throws Exception {
         // given
-        Connection connection = savedConnections.get(0);
+        ConnectionEntity connection = savedConnections.get(0);
         // when
         Response response = api.getConnection(connection.getId());
         // then
@@ -85,14 +85,14 @@ public class ConnectionsApiIT {
         // given
         // - prepare connection
         ConnectionBuilder builder = new ConnectionBuilder().setName("connection3");
-        Connection connection = builder.build();
+        ConnectionEntity connection = builder.build();
         // when
         Response response = api.addConnection(connection);
         // then
         response.then().statusCode(HttpStatus.CREATED.value());
         String actual = response.print();
         // - prepare expected connection (received as response) with ID
-        Connection expectedConnection = builder.build();
+        ConnectionEntity expectedConnection = builder.build();
         String location = response.header("Location");
         long id = Long.parseLong(location.replaceAll("^.*/", ""));
         expectedConnection.setId(id);
@@ -107,7 +107,7 @@ public class ConnectionsApiIT {
     public void updatesConnectionAndReturnsResourceOnPut() throws Exception {
         // given
         final String newDbName = "completelyNewDatabaseName123";
-        Connection connection = savedConnections.get(0);
+        ConnectionEntity connection = savedConnections.get(0);
         connection.setDatabaseName(newDbName);
         // when
         Response response = api.updateConnection(connection);
@@ -125,7 +125,7 @@ public class ConnectionsApiIT {
     @Test
     public void deletesConnectionAndReturnsResourceOnDelete() throws Exception {
         // given
-        Connection connection = savedConnections.get(0);
+        ConnectionEntity connection = savedConnections.get(0);
         // when
         Response response = api.deleteConnection(connection.getId());
         // then
@@ -144,10 +144,11 @@ public class ConnectionsApiIT {
         // given
         // - prepare connection
         ConnectionBuilder builder = new ConnectionBuilder().setName(null);
-        Connection connection = builder.build();
+        ConnectionEntity connection = builder.build();
         // when
         Response response = api.addConnection(connection);
         // then
+        String s = response.prettyPrint();
         response.then().statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
@@ -163,8 +164,8 @@ public class ConnectionsApiIT {
             return this;
         }
 
-        public Connection build() {
-            return new Connection(name, hostName, databaseName, userName, password);
+        public ConnectionEntity build() {
+            return new ConnectionEntity(name, hostName, databaseName, userName, password);
         }
     }
 }

--- a/src/test/java/cz/blahami2/dbviewer/connections/ConnectionsApiWrapper.java
+++ b/src/test/java/cz/blahami2/dbviewer/connections/ConnectionsApiWrapper.java
@@ -1,7 +1,7 @@
 package cz.blahami2.dbviewer.connections;
 
 import com.jayway.restassured.response.Response;
-import cz.blahami2.dbviewer.data.entity.Connection;
+import cz.blahami2.dbviewer.data.entity.ConnectionEntity;
 import cz.blahami2.dbviewer.shared.testapi.JsonRestApi;
 
 public class ConnectionsApiWrapper {
@@ -20,13 +20,13 @@ public class ConnectionsApiWrapper {
                 .get(BASE_PATH + "/" + id);
     }
 
-    public Response addConnection(Connection connection) {
+    public Response addConnection(ConnectionEntity connection) {
         return api.givenJsonHeaders()
                 .body(connection)
                 .post(BASE_PATH);
     }
 
-    public Response updateConnection(Connection connection) {
+    public Response updateConnection(ConnectionEntity connection) {
         return api.givenJsonHeaders()
                 .body(connection)
                 .put(BASE_PATH + "/" + connection.getId());

--- a/src/test/java/cz/blahami2/dbviewer/connections/ConnectionsDetailsApiIT.java
+++ b/src/test/java/cz/blahami2/dbviewer/connections/ConnectionsDetailsApiIT.java
@@ -2,10 +2,10 @@ package cz.blahami2.dbviewer.connections;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.restassured.RestAssured;
+import cz.blahami2.dbviewer.data.entity.ConnectionEntity;
 import cz.blahami2.dbviewer.model.Column;
 import cz.blahami2.dbviewer.model.Preview;
 import cz.blahami2.dbviewer.model.Schema;
-import cz.blahami2.dbviewer.data.entity.Connection;
 import cz.blahami2.dbviewer.data.repository.ConnectionsRepository;
 import cz.blahami2.dbviewer.model.Table;
 import lombok.var;
@@ -50,7 +50,7 @@ public class ConnectionsDetailsApiIT {
             .build();
 
     private ConnectionsDetailsApiWrapper api;
-    private Connection connection;
+    private ConnectionEntity connection;
     private ObjectMapper objectMapper = new ObjectMapper();
 
 
@@ -60,7 +60,7 @@ public class ConnectionsDetailsApiIT {
         this.api = new ConnectionsDetailsApiWrapper();
         repository.deleteAll();
         database.waitForLogMessage("/usr/local/bin/docker-entrypoint.sh:", 5_000);
-        connection = repository.save(new Connection("connection1",
+        connection = repository.save(new ConnectionEntity("connection1",
                 database.getDockerHost() + ":" + database.getExposedContainerPort("5432"), DB_NAME, DB_USER, DB_PASS
         ));
     }

--- a/src/test/java/cz/blahami2/dbviewer/connections/DatabaseDetailsServiceTest.java
+++ b/src/test/java/cz/blahami2/dbviewer/connections/DatabaseDetailsServiceTest.java
@@ -1,11 +1,7 @@
 package cz.blahami2.dbviewer.connections;
 
 import cz.blahami2.dbviewer.data.DatabaseConnection;
-import cz.blahami2.dbviewer.data.entity.Connection;
-import cz.blahami2.dbviewer.model.Column;
-import cz.blahami2.dbviewer.model.Preview;
-import cz.blahami2.dbviewer.model.Schema;
-import cz.blahami2.dbviewer.model.Table;
+import cz.blahami2.dbviewer.model.*;
 import lombok.var;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- `Connection` is now a simple POJO, separated from `ConnectionEntity`, which is a database entity